### PR TITLE
Support connect-history-api-fallback options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,15 +18,13 @@ var plugin = {
         "client:js": "",
         "client:events": function () {
             return HISTORY_CHANGE_EVENT;
-        },
-        "server:middleware": function () {
-            return historyApiFallback
         }
     }
 }
 
 const defaults = {
-    selector: "[ng-app]"
+    selector: "[ng-app]",
+    history: {}
 };
 
 /**
@@ -37,5 +35,13 @@ module.exports = function (opts) {
     var config   = merger.set({simple: true}).merge(defaults, opts);
     var clientJs = require("fs").readFileSync(__dirname + CLIENT_JS, "utf-8");
     plugin.hooks["client:js"] = clientJs.replace("%SELECTOR%", config.selector);
+
+    if (config.history) {
+        plugin.hooks["server:middleware"] = function () {
+            return historyApiFallback(config.history);
+        };
+    }
+
+
     return plugin;
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "supertest": "^0.15.0"
   },
   "dependencies": {
-    "connect-history-api-fallback": "0.0.5",
+    "connect-history-api-fallback": "^1.1.0",
     "opt-merger": "^1.1.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,16 @@ var browserSync = require("browser-sync");
 var spa         = require("browser-sync-spa");
 
 browserSync.use(spa({
-    selector: "[ng-app]" // Only needed for angular apps
+
+    // Only needed for angular apps
+    selector: "[ng-app]",
+
+    // Options to pass to connect-history-api-fallback.
+    // If your application already provides fallback urls (such as an existing proxy server),
+    // this value can be set to false to omit using the connect-history-api-fallback middleware entirely.
+    history: {
+        index: '/index.html'
+    }
 }));
 
 browserSync({


### PR DESCRIPTION
Hello again,

This PR updates the connect-history-api-fallback dependency to it's 1.x version and provides a history option so that it [history api fallback] can be configured (or removed entirely).

Note that setting `{ history: false }` does not use the history fallback middleware at all, which is useful if the fallback pages are already being provided (such as through a proxy server).

Passing config to the history api fallback will help when:
- a proxy server is being used and the proxy provides the route responses
- the default index page (index.html) requires a different filename
- different html needs to be served for different routes (such as embedded json to bootstrap the app)
- end users need to apply additional configuration to rewrite urls - see #5 

Not sure if option name `history` should be something else? webpack-dev-server calls the option `historyApiFallback`. 

Thoughts?
