### PR TITLE
Fixed wrong path for angular's $location.path when using a base href

### DIFF
--- a/client.js
+++ b/client.js
@@ -4,6 +4,8 @@
 
     var sockets = bs.socket;
 
+    var base = document.querySelector('base') && document.querySelector('base').getAttribute('href');
+
     (function(history){
         var pushState = history.pushState;
         history.pushState = function(state) {
@@ -53,6 +55,11 @@
 
             if (!elem) {
                 return;
+            }
+
+            // remove base href from pathname to compare it with $location.path
+            if (base) {
+                pathname = pathname.replace(base, '/');
             }
 
             var $injector  = angular.element(elem).injector();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var historyApiFallback = require("connect-history-api-fallback");
-var merger = require("opt-merger");
 
 const PLUGIN_NAME          = "BrowserSync SPA";
 const HISTORY_CHANGE_EVENT = "history:change";
@@ -32,7 +31,7 @@ const defaults = {
  * @param opts
  */
 module.exports = function (opts) {
-    var config   = merger.set({simple: true}).merge(defaults, opts);
+    var config   = Object.assign({}, defaults, opts);
     var clientJs = require("fs").readFileSync(__dirname + CLIENT_JS, "utf-8");
     plugin.hooks["client:js"] = clientJs.replace("%SELECTOR%", config.selector);
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "supertest": "^0.15.0"
   },
   "dependencies": {
-    "connect-history-api-fallback": "^1.1.0",
-    "opt-merger": "^1.1.0"
+    "connect-history-api-fallback": "^1.1.0"
   }
 }


### PR DESCRIPTION
I'm using a `<base href="/client/">` for certain reasons.

Due to that the path provided to Angular's `$location.path` was not correct. It contained the the base path too (e.g. `/client/profile` instead of just `/profile`), which caused my web app to display the 404 error state.

That's why I removed the base href from `pathname` variable when it's avialable.