### PR TITLE
doc(readme): Fix formatting mistakes.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
-BrowserSync SPA
+# BrowserSync SPA
 
 > Better Single Page App support for BrowserSync
 
-#Install
+# Install
 
 ```shell
 $ npm install browser-sync browser-sync-spa
 ```
 
-#Setup
+# Setup
 ```js
 var browserSync = require("browser-sync");
 var spa         = require("browser-sync-spa");
@@ -33,7 +33,7 @@ browserSync({
 });
 ```
 
-#What you get.
+# What you get
 
 This first release simple addresses two of the most requested features in 
 BrowserSync.
@@ -41,7 +41,7 @@ BrowserSync.
 * Built-in history API fallback
 * State-change syncing for Backbone + Angular apps.
 
-#Moving forward.
+# Moving forward
 
 I really need some contributors with SPA experience that can help make this plugin awesome.
 BrowserSync is already the best solution for live reload + css injecting on SPA's, but 
@@ -49,8 +49,8 @@ it's clear we can do better.
 
 Please get involved if you have any experience with HTML5 history api etc.
 
-#Help
+# Help
 Clone this repo and run `npm install && npm test.js` to get an idea of what this plugin will do for you.
 
-#Resources
+# Resources
 [BrowserSync](https://github.com/shakyShane/browser-sync)

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ $ npm install browser-sync browser-sync-spa
 ```
 
 # Setup
+
 ```js
 var browserSync = require("browser-sync");
 var spa         = require("browser-sync-spa");
@@ -35,22 +36,21 @@ browserSync({
 
 # What you get
 
-This first release simple addresses two of the most requested features in 
-BrowserSync.
+This first release simple addresses two of the most requested features in BrowserSync.
 
 * Built-in history API fallback
 * State-change syncing for Backbone + Angular apps.
 
 # Moving forward
 
-I really need some contributors with SPA experience that can help make this plugin awesome.
-BrowserSync is already the best solution for live reload + css injecting on SPA's, but 
-it's clear we can do better.
+I really need some contributors with SPA experience that can help make this plugin awesome. BrowserSync is already the best solution for live reload + css injecting on SPA's, but it's clear we can do better.
 
 Please get involved if you have any experience with HTML5 history api etc.
 
 # Help
+
 Clone this repo and run `npm install && npm test.js` to get an idea of what this plugin will do for you.
 
 # Resources
+
 [BrowserSync](https://github.com/shakyShane/browser-sync)


### PR DESCRIPTION
I like your project and thought it should have a better-formatted, public-facing readme. :-)

As it stands, the readme doesn't correctly use markdown, so the section titles are broken.

## Before

![readmebefore](https://user-images.githubusercontent.com/8163408/45458149-2452cd00-b6a7-11e8-9f60-baa7af1aeb75.png)

This PR fixes the title formatting mistakes and standardizes the paragraph spacing; there were some strange line breaks.

## After
![screen shot 2018-09-12 at 4 11 20 pm](https://user-images.githubusercontent.com/8163408/45458216-74319400-b6a7-11e8-85fe-ea9429faaf96.png)
